### PR TITLE
- Fix deep object selection in array

### DIFF
--- a/src/core/notation.js
+++ b/src/core/notation.js
@@ -858,7 +858,9 @@ class Notation {
                             return false;
                         }
                         // console.log('  » setting', levelNotation, '=', value);
-                        filtered.set(levelNotation, value, 'overwrite');
+                        if(originalNotation == levelNotation) {
+                            filtered.set(levelNotation, value, 'overwrite');
+                        }
                     }
                 });
             }, reverseIterateIfArray);

--- a/src/utils.js
+++ b/src/utils.js
@@ -70,7 +70,7 @@ const utils = {
             return keyOrIndex && objProto.hasOwnProperty.call(collection, keyOrIndex);
         }
         if (typeof keyOrIndex === 'number') {
-            return keyOrIndex >= 0 && keyOrIndex < collection.length;
+            return keyOrIndex >= 0 && collection[keyOrIndex] !== undefined
         }
         return false;
     },


### PR DESCRIPTION
Exemple :
[
"acheteur._id",
"acheteur.nom",
"vendeur._id",
"vendeur.nom",
"lignes[*].vente._id" // Ne fonctionnnait pas auparavent ]